### PR TITLE
feat(comic): 修正切页方法命名错误；新增切页动画；使切换章节功能更符合逻辑

### DIFF
--- a/lib/views/reader/comic_reader.dart
+++ b/lib/views/reader/comic_reader.dart
@@ -231,9 +231,9 @@ class _ComicReaderPageState extends State<ComicReaderPage> {
                     onTap: () {
                       if (Provider.of<AppSetting>(context, listen: false)
                           .comicReadReverse) {
-                        previousPage();
-                      } else {
                         nextPage();
+                      } else {
+                        previousPage();
                       }
                     },
                     child: Container(),
@@ -249,9 +249,9 @@ class _ComicReaderPageState extends State<ComicReaderPage> {
                     onTap: () {
                       if (Provider.of<AppSetting>(context, listen: false)
                           .comicReadReverse) {
-                        nextPage();
-                      } else {
                         previousPage();
+                      } else {
+                        nextPage();
                       }
                     },
                     child: Container(),
@@ -483,7 +483,7 @@ class _ComicReaderPageState extends State<ComicReaderPage> {
     );
   }
 
-  void nextPage() async {
+  void previousPage() async {
     if (_pageController.page == 1) {
       previousChapter();
       setState(() {
@@ -500,17 +500,17 @@ class _ComicReaderPageState extends State<ComicReaderPage> {
         } else {
           newPage = _selectIndex - 1;
         }
-        _pageController.jumpToPage(newPage);
+        _pageController.animateToPage(newPage, duration: Duration(milliseconds: 200), curve: Curves.easeInOut);
       });
     }
   }
 
-  void previousPage() {
+  void nextPage() {
     if (_pageController.page > _detail.page_url.length) {
       nextChapter();
     } else {
       setState(() {
-        _pageController.jumpToPage(_selectIndex + 1);
+        _pageController.animateToPage(_selectIndex + 1, duration: Duration(milliseconds: 200), curve: Curves.easeInOut);
       });
     }
   }
@@ -927,7 +927,7 @@ class _ComicReaderPageState extends State<ComicReaderPage> {
   bool _loading = false;
   ComicWebChapterDetail _detail;
   DefaultCacheManager _cacheManager = DefaultCacheManager();
-  Future loadData() async {
+  Future loadData({isFirstLoad = true, isNextChapter = false}) async {
     try {
       if (_loading) {
         return;
@@ -943,7 +943,7 @@ class _ComicReaderPageState extends State<ComicReaderPage> {
         detail = await getV4Detail();
       }
       var historyItem = await ComicHistoryProvider.getItem(widget.comicId);
-      if (historyItem != null &&
+      if (isFirstLoad && historyItem != null &&
           historyItem.chapter_id == _currentItem.chapterId) {
         var page = historyItem.page.toInt();
         if (page > detail.page_url.length) {
@@ -955,9 +955,11 @@ class _ComicReaderPageState extends State<ComicReaderPage> {
         });
         // _pageController.=;
       } else {
-        _pageController = new PreloadPageController(initialPage: 1);
+        int page = isNextChapter || isFirstLoad ? 1 : detail.page_url.length;
+
+        _pageController = new PreloadPageController(initialPage: page);
         setState(() {
-          _selectIndex = 1;
+          _selectIndex = page;
         });
       }
 
@@ -1049,7 +1051,7 @@ class _ComicReaderPageState extends State<ComicReaderPage> {
     setState(() {
       _currentItem = widget.chapters[widget.chapters.indexOf(_currentItem) + 1];
     });
-    await loadData();
+    await loadData(isFirstLoad: false, isNextChapter: true);
   }
 
   void previousChapter() async {
@@ -1060,6 +1062,6 @@ class _ComicReaderPageState extends State<ComicReaderPage> {
     setState(() {
       _currentItem = widget.chapters[widget.chapters.indexOf(_currentItem) - 1];
     });
-    await loadData();
+    await loadData(isFirstLoad: false, isNextChapter: false);
   }
 }

--- a/lib/widgets/comic_view.dart
+++ b/lib/widgets/comic_view.dart
@@ -177,7 +177,10 @@ class _ComicViewState extends State<ComicView> {
             key: ObjectKey(index),
             imageProvider: pageOption.imageProvider,
             loadingBuilder: widget.loadingBuilder,
-            loadFailedChild: widget.loadFailedChild,
+            // errorBuilder: widget.loadFailedChild,
+            errorBuilder: (BuildContext context, Object exception, StackTrace stackTrace) {
+              return widget.loadFailedChild;
+            },
             backgroundDecoration: widget.backgroundDecoration,
             controller: pageOption.controller,
             scaleStateController: pageOption.scaleStateController,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   carousel_slider: ^2.3.1
   common_utils: ^2.1.0
   webview_flutter: ^1.0.4
-  photo_view: ^0.10.2
+  photo_view: ^0.14.0
   fluttertoast: ^8.0.8
   sqflite: ^1.3.1+2
   url_launcher: ^5.7.5


### PR DESCRIPTION
- 增加了点击左右两边切页时的动画
- 对切章节的功能做了点修改，使其更符合逻辑
    - 切上一话initialPage为最后一页
    - 切下一话initialPage为第一页
    - 从漫画详情任意点一话如果有历史记录则initialPage为历史记录页，否则为第一页

~~为啥上一页和下一页的方法名是反过来的啊~~