### PR TITLE
id跳转标识模式改为id###

### DIFF
--- a/lib/modules/comic/search/comic_search_controller.dart
+++ b/lib/modules/comic/search/comic_search_controller.dart
@@ -44,7 +44,7 @@ class ComicSearchController extends BasePageController<SearchComicItem> {
       return;
     }
 
-    if (searchController.text.startsWith("id:\\") && await handelJumpComic()) {
+    if (searchController.text.startsWith("id") && await handelJumpComic()) {
       return;
     }
 
@@ -54,7 +54,7 @@ class ComicSearchController extends BasePageController<SearchComicItem> {
   }
 
   Future<bool> handelJumpComic() async {
-    var id = int.tryParse(searchController.text.replaceAll("id:\\", "")) ?? 0;
+    var id = int.tryParse(searchController.text.replaceAll("id", "")) ?? 0;
     if (id != 0) {
       AppNavigator.toComicDetail(id);
       return true;


### PR DESCRIPTION
只有一部漫画 ID:INVADED #BRAKE BROKEN是以id开头的，还不是小写，还不包括数字。 输入半角冒号和反斜杠对手机不大友好

另外左右跳转区只有10%真的太窄了，非常容易误触，哪怕留25%也好，中间滑动区留50%宽度不会耽误滑动的。

https://github.com/xiaoyaocz/flutter_dmzj/pull/157