### PR TITLE
点击换一批按钮时旋转加载图标

### DIFF
--- a/lib/modules/comic/home/recommend/comic_recommend_controller.dart
+++ b/lib/modules/comic/home/recommend/comic_recommend_controller.dart
@@ -48,7 +48,7 @@ class ComicRecommendController extends BasePageController<ComicRecommendModel> {
   }
 
   /// 加载随机漫画
-  void loadRandom() async {
+  Future<void> loadRandom() async {
     try {
       var result = await request.refreshRecommend(50);
       var index = list.indexWhere((x) => x.categoryId == 50);
@@ -66,7 +66,7 @@ class ComicRecommendController extends BasePageController<ComicRecommendModel> {
   }
 
   /// 刷新国漫
-  void refreshGuoman() async {
+  Future<void> refreshGuoman() async {
     try {
       var result = await request.refreshRecommend(52);
       var index = list.indexWhere((x) => x.categoryId == 52);
@@ -94,7 +94,7 @@ class ComicRecommendController extends BasePageController<ComicRecommendModel> {
   }
 
   /// 刷新热门连载
-  void refreshHot() async {
+  Future<void> refreshHot() async {
     try {
       var result = await request.refreshRecommend(54);
       var index = list.indexWhere((x) => x.categoryId == 54);

--- a/lib/modules/comic/home/recommend/comic_recommend_view.dart
+++ b/lib/modules/comic/home/recommend/comic_recommend_view.dart
@@ -5,10 +5,10 @@ import 'package:flutter_dmzj/modules/comic/home/recommend/comic_recommend_contro
 import 'package:flutter_dmzj/widgets/keep_alive_wrapper.dart';
 import 'package:flutter_dmzj/widgets/net_image.dart';
 import 'package:flutter_dmzj/widgets/page_list_view.dart';
+import 'package:flutter_dmzj/widgets/refresh_until_widget.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:flutter_swiper_view/flutter_swiper_view.dart';
 import 'package:get/get.dart';
-import 'package:remixicon/remixicon.dart';
 
 class ComicRecommendView extends StatelessWidget {
   final ComicRecommendController controller;
@@ -154,20 +154,8 @@ class ComicRecommendView extends StatelessWidget {
     );
   }
 
-  Widget buildRefresh({required Function() onRefresh}) {
-    return GestureDetector(
-      onTap: onRefresh,
-      child: const Row(
-        children: [
-          Icon(Remix.refresh_line, size: 18, color: Colors.grey),
-          AppStyle.hGap4,
-          Text(
-            "换一批",
-            style: TextStyle(fontSize: 14, color: Colors.grey),
-          ),
-        ],
-      ),
-    );
+  Widget buildRefresh({required Future Function() onRefresh}) {
+    return RefreshUntilWidget(onRefresh: onRefresh, text: "换一批");
   }
 
   Widget buildBanner(ComicRecommendModel item) {

--- a/lib/modules/novel/home/recommend/novel_recommend_view.dart
+++ b/lib/modules/novel/home/recommend/novel_recommend_view.dart
@@ -9,7 +9,6 @@ import 'package:flutter_dmzj/widgets/refresh_until_widget.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:flutter_swiper_view/flutter_swiper_view.dart';
 import 'package:get/get.dart';
-import 'package:remixicon/remixicon.dart';
 
 class NovelRecommendView extends StatelessWidget {
   final NovelRecommendController controller;

--- a/lib/modules/novel/home/recommend/novel_recommend_view.dart
+++ b/lib/modules/novel/home/recommend/novel_recommend_view.dart
@@ -5,6 +5,7 @@ import 'package:flutter_dmzj/modules/novel/home/recommend/novel_recommend_contro
 import 'package:flutter_dmzj/widgets/keep_alive_wrapper.dart';
 import 'package:flutter_dmzj/widgets/net_image.dart';
 import 'package:flutter_dmzj/widgets/page_list_view.dart';
+import 'package:flutter_dmzj/widgets/refresh_until_widget.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:flutter_swiper_view/flutter_swiper_view.dart';
 import 'package:get/get.dart';
@@ -98,20 +99,8 @@ class NovelRecommendView extends StatelessWidget {
     );
   }
 
-  Widget buildRefresh({required Function() onRefresh}) {
-    return GestureDetector(
-      onTap: onRefresh,
-      child: const Row(
-        children: [
-          Icon(Remix.refresh_line, size: 18, color: Colors.grey),
-          AppStyle.hGap4,
-          Text(
-            "换一批",
-            style: TextStyle(fontSize: 14, color: Colors.grey),
-          ),
-        ],
-      ),
-    );
+  Widget buildRefresh({required Future Function() onRefresh}) {
+    return RefreshUntilWidget(onRefresh: onRefresh, text: "换一批");
   }
 
   Widget buildBanner(NovelRecommendModel item) {

--- a/lib/widgets/refresh_until_widget.dart
+++ b/lib/widgets/refresh_until_widget.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dmzj/app/app_style.dart';
+import 'package:remixicon/remixicon.dart';
+
+/// 一个加载图标会旋转的加载按钮。加载图标（[Remix.refresh_line]）在左，文字（[text])在
+/// 右。
+///
+/// 在点击widget时会在执行[onRefresh]函数的同时旋转加载图标。加载图标会一直旋转直到该函数
+/// 返还。
+///
+/// 加载图标会旋转不小于1秒的时间，即如果[onRefresh]函数在1秒之内执行完毕，加载图标会继续旋
+/// 转直到距离onRefresh函数开始执行已经过了1秒。
+class RefreshUntilWidget extends StatefulWidget {
+  final Future Function() onRefresh;
+  final String text;
+
+  const RefreshUntilWidget({
+    super.key,
+    required this.onRefresh,
+    required this.text,
+  });
+
+  @override
+  State<RefreshUntilWidget> createState() => _RefreshUntilWidgetState();
+}
+
+class _RefreshUntilWidgetState extends State<RefreshUntilWidget>
+    with TickerProviderStateMixin {
+  late final AnimationController _controller = AnimationController(
+    duration: const Duration(seconds: 1),
+    vsync: this,
+  );
+  late final Animation<double> _animation = CurvedAnimation(
+    parent: _controller,
+    curve: Curves.linear,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () async {
+        _controller.repeat();
+        // 确保在网络很好的情况下，动画不会太快结束（至少1秒）
+        await Future.wait([
+          widget.onRefresh(),
+          Future.delayed(const Duration(seconds: 1)),
+        ]);
+        _controller.stop(canceled: false);
+      },
+      child: Row(
+        children: [
+          RotationTransition(
+            turns: _animation,
+            child: const Icon(Remix.refresh_line, size: 18, color: Colors.grey),
+          ),
+          AppStyle.hGap4,
+          Text(
+            widget.text,
+            style: const TextStyle(fontSize: 14, color: Colors.grey),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
首先，非常感谢作者的无私的开发！

在点击漫画页面的"换一批“按钮时，没有UI上的反馈到底有没有刷新了一批漫画。在”换一批“经常会给相同的漫画的情况下，更不知道到底是网出了问题还是单纯地给了相同的一批。如果能让加载图标旋转起来，这样就知道到底有没有真正的”换一批“了。

|before|after|
|----------|-------|
|![dmzj_before_spinner](https://github.com/xiaoyaocz/flutter_dmzj/assets/74938940/93c717cb-b6f0-4289-b55e-921ab7a0985f)|![dmzj_after_spinner](https://github.com/xiaoyaocz/flutter_dmzj/assets/74938940/938ef972-f853-4caa-b30f-12598dbb7e18)|




