### PR TITLE
修正"选择下载章节"页中错误的提示框文字

### DIFF
--- a/lib/modules/comic/select_chapter/comic_select_chapter_controller.dart
+++ b/lib/modules/comic/select_chapter/comic_select_chapter_controller.dart
@@ -142,6 +142,6 @@ class ComicSelectChapterController extends BaseController {
       );
     }
     chapterIds.clear();
-    SmartDialog.showToast("已添加到下载列表，下载过程中请保存APP在前台运行");
+    SmartDialog.showToast("已添加到下载列表，下载过程中请保持APP在前台运行");
   }
 }

--- a/lib/modules/novel/select_chapter/novel_select_chapter_controller.dart
+++ b/lib/modules/novel/select_chapter/novel_select_chapter_controller.dart
@@ -121,6 +121,6 @@ class NovelSelectChapterController extends BaseController {
       );
     }
     cleanAll();
-    SmartDialog.showToast("已添加到下载列表，下载过程中请保存APP在前台运行");
+    SmartDialog.showToast("已添加到下载列表，下载过程中请保持APP在前台运行");
   }
 }


### PR DESCRIPTION
![image](https://github.com/xiaoyaocz/flutter_dmzj/assets/94725606/c338b9b8-c177-4b08-b4cb-6551a2486829)
非常棒的软件，这个 pr 修复一个微小的文字问题。
之前使用的时候就注意到了，但是只是个弹窗一弹就没，就以为是自己看错了。今天缓存的时候再次注意到了这个问题。

## 这个 pr 做了什么

将两处“下载过程中请**保存**APP在前台运行”改为“下载过程中请**保持**APP在前台运行”