### PR TITLE
feat: updated API to include coreToken generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,10 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# FVM Version Cache
+.fvm/
+
+.vscode
+/ext_projs
+ios/Flutter/flutter_export_environment.sh

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -68,7 +68,7 @@ android {
     }
     buildTypes {
         debug {
-            signingConfig signingConfigs.release
+            signingConfig signingConfigs.debug
         }
         profile {
             signingConfig signingConfigs.release

--- a/lib/requests/comic_request.dart
+++ b/lib/requests/comic_request.dart
@@ -19,6 +19,7 @@ import 'package:flutter_dmzj/models/comic/view_point_model.dart';
 import 'package:flutter_dmzj/models/comic/web_search_model.dart';
 import 'package:flutter_dmzj/models/db/download_status.dart';
 import 'package:flutter_dmzj/models/proto/comic.pb.dart';
+import 'package:flutter_dmzj/requests/common/api.dart';
 import 'package:flutter_dmzj/requests/common/http_client.dart';
 import 'package:flutter_dmzj/services/comic_download_service.dart';
 import 'package:flutter_dmzj/services/user_service.dart';
@@ -250,12 +251,19 @@ class ComicRequest {
     return info;
   }
 
-  /// 漫画详情
+  static const String COMIC_UA = "Android,DMZJ1,${Api.VERSION}";
+  static const String COMIC_DEFAULT_UID = "2665531";
+  /// 漫画详情 V4, updated api
   Future<ComicDetailProto> comicDetailV4({
     required int comicId,
   }) async {
+    // Use getEncryptV2 which includes coreToken and correct UA
     var result = await HttpClient.instance.getEncryptV4(
-      '/comic/detail/$comicId?uid=2665531',
+      '/v2/comic/detail/$comicId?uid=$COMIC_DEFAULT_UID',
+      customHeaders: {
+        "User-Agent": COMIC_UA,
+      },
+      useCoreToken: true
     );
     var data = ComicDetailResponseProto.fromBuffer(result);
     if (data.errno != 0) {
@@ -344,12 +352,17 @@ class ComicRequest {
     return info;
   }
 
-  /// 章节详情-V4
+  /// 章节详情-V4, updated with 3.9.1 apk results.
   Future<ComicChapterDetailProto> chapterDetailV4(
       {required int comicId, required int chapterId}) async {
+    var uid = UserService.instance.userId ?? COMIC_DEFAULT_UID;
     var result = await HttpClient.instance.getEncryptV4(
-      '/comic/chapter/$comicId/$chapterId',
-      needLogin: true,
+      '/v2/comic/chapter/$comicId/$chapterId?uid=$uid',
+      needLogin: false,
+      useCoreToken: true,
+      customHeaders: {
+        "User-Agent": COMIC_UA,
+      }
     );
     var data = ComicChapterResponseProto.fromBuffer(result);
     if (data.errno != 0) {

--- a/lib/requests/comic_request.dart
+++ b/lib/requests/comic_request.dart
@@ -355,7 +355,7 @@ class ComicRequest {
   /// 章节详情-V4, updated with 3.9.1 apk results.
   Future<ComicChapterDetailProto> chapterDetailV4(
       {required int comicId, required int chapterId}) async {
-    var uid = UserService.instance.userId ?? COMIC_DEFAULT_UID;
+    var uid = COMIC_DEFAULT_UID;
     var result = await HttpClient.instance.getEncryptV4(
       '/v2/comic/chapter/$comicId/$chapterId?uid=$uid',
       needLogin: false,

--- a/lib/requests/common/api.dart
+++ b/lib/requests/common/api.dart
@@ -33,13 +33,26 @@ class Api {
   static const String BASE_URL_INTERFACE =
       "http://nninterface.$IDMZJ_DOMAIN_NAME";
 
-  /// V4 API的密钥
+  /// V4 API key in 3.9.1 apk, the block size is 256.
+  static const V4_PRIVATE_KEY_NEW =
+      "MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCdZs58QzMFomC+04F8R/yIzLmEwCHto93zAMG+KYSTaidVCkVvnNBE6g5xXAQgnGjwDDsJUV0m2jNtLiVTG7yNv5c1PvRm/9XH9uo91z/X//s03n1px/sOqmCYk2ezkbojUADY74pBrVfgIMu71mXtKK640/hyQLZIrRfpTjiHHfykulL8v5BTY99llwTMC8oIPVXmUIYKMZORRYhC0bgOpJeOq6PI+3qpf/gWigVcH2+qMR+6Bi0HLg3s5rYdYxxP+kaZmMmTRO7NxCfYlNri8NwX2Lgk9IE0he5i0OQCgGjqQ5vxAv52XwJB3jCxmEeVJmiMbrrs+ggAp7rNLzv/AgMBAAECggEAKcGeQaTqIjKDi9w8W6YVPo1hIfB+j7aLKO4od7Q38YuVx5+j8AofzkhxcG1Cwwv7YsM73irxlV8JiYtWZ4fSK6CKEpwS5kg0hInidmlmDH1iPRJRHwDof2l/mrpwJlkgkkGlF+fkO6wqxdCte7VS8Ol8AJhrLpQwR3N0Bnaz1FQboaxy28MJ53kJBkM8u0J3hHIx+0s57qdh/MuHnd0Q8lcxnXM9JYhSCwOHmcGdR/G29l1S8JF9w1O8RPprPjYGBTh2JhqaQ4zBx/2Q/Uk7/l0X7BcpFzzpyuc0q2OCOOhAIyJKITvxiEsrt/OoNxoCUXMoEtQ63tXtrBMN+aNNgQKBgQDP43C/f/p1CaKOzmH9gl+rIKHpWbRZowolFKjN5u9T/Yep/fOqYufVXFzKfuoBPj2k/MbFUhHkO/WE3Oqcis4/pdt+7H1tooK2kptZNJZGaK1w4wJ5Gm3b28sQsUtG1QtJhBcj4j2fuRiCbOAV43OdWKrsse5efmd0pZLqth+4IQKBgQDB1DjP00Nb+uB+c/t4c/GFQYTjpgG5lUf+IuNmQvXfym7xrb4mU5czV/OUWa0L9OdfqJxtOb4QW4c6oRll+8Et5V1POLajYaaqTjFr2y21fu4DNGEUsAd4UmI7GMwAtYE9gUo5KWRLgXRDTD2fqvpTbbqSDuqHcPI36qnxF5nwHwKBgE+L0tej670e67HDLOGpIlxDx1CX/5eQ+E/KAPGQnSFBUMjuIG+hGt6cUfE18Op623GnO5PDXI89liu5sJgn0NWv7DY73Z624Vdk78aJhbr5UOxyIL8gKstG5gPEI26+FGyT+5rCdhwI4mT9rh0SBGo/xF9/khtcOM/8jyP6flahAoGBAIq/YL+cCi7Qglzip1NNI8lw4jCXR8rSCovn64HrUtgUr6A+78u9sJFnVwyNuOrDL9DxALDLUbuh2UZlxamUMm+pLUclYM/JeiWU/ZmodqriJnySxR+q9l3yEzEcigPD6bTeVQRgFdRa4Z++9qnSGYkZFiGxnb7AYhMW3vmfHGmfAoGBAKWhB0e7dgg61ezjMrKkiaIlcrWkKkpNZ/i9B72rDnPr115x56laOaIu3D8Cuh8o+zGqRuyABBK5cDMPy/DagghrI4H6yhfnevUKD94F/XKQIVWXb5in9mwibAiHBrmLQ7fLUDoyhRmERsZYduS4inHzYFEHhjq4jUfQsOV9xKdu";
+
+  /// V4 API的密钥 
   static const V4_PRIVATE_KEY =
       "MIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAK8nNR1lTnIfIes6oRWJNj3mB6OssDGx0uGMpgpbVCpf6+VwnuI2stmhZNoQcM417Iz7WqlPzbUmu9R4dEKmLGEEqOhOdVaeh9Xk2IPPjqIu5TbkLZRxkY3dJM1htbz57d/roesJLkZXqssfG5EJauNc+RcABTfLb4IiFjSMlTsnAgMBAAECgYEAiz/pi2hKOJKlvcTL4jpHJGjn8+lL3wZX+LeAHkXDoTjHa47g0knYYQteCbv+YwMeAGupBWiLy5RyyhXFoGNKbbnvftMYK56hH+iqxjtDLnjSDKWnhcB7089sNKaEM9Ilil6uxWMrMMBH9v2PLdYsqMBHqPutKu/SigeGPeiB7VECQQDizVlNv67go99QAIv2n/ga4e0wLizVuaNBXE88AdOnaZ0LOTeniVEqvPtgUk63zbjl0P/pzQzyjitwe6HoCAIpAkEAxbOtnCm1uKEp5HsNaXEJTwE7WQf7PrLD4+BpGtNKkgja6f6F4ld4QZ2TQ6qvsCizSGJrjOpNdjVGJ7bgYMcczwJBALvJWPLmDi7ToFfGTB0EsNHZVKE66kZ/8Stx+ezueke4S556XplqOflQBjbnj2PigwBN/0afT+QZUOBOjWzoDJkCQClzo+oDQMvGVs9GEajS/32mJ3hiWQZrWvEzgzYRqSf3XVcEe7PaXSd8z3y3lACeeACsShqQoc8wGlaHXIJOHTcCQQCZw5127ZGs8ZDTSrogrH73Kw/HvX55wGAeirKYcv28eauveCG7iyFR0PFB/P/EDZnyb+ifvyEFlucPUI0+Y87F";
+  
   static Uint8List decryptV4(String text) {
+    return decryptWithKey(text, V4_PRIVATE_KEY);
+  }
+
+  static Uint8List decryptV4New(String text) {
+    return decryptWithKey(text, V4_PRIVATE_KEY_NEW);
+  }
+
+  static Uint8List decryptWithKey(String text, String key) {
     try {
       RSAKeypair rsaKeypair =
-          RSAKeypair(RSAPrivateKey.fromString(V4_PRIVATE_KEY));
+          RSAKeypair(RSAPrivateKey.fromString(key));
       var decrypted = rsaKeypair.privateKey.decryptData(base64.decode(text));
       return decrypted;
     } catch (e) {
@@ -54,17 +67,38 @@ class Api {
     return md5.convert(utf8Content).toString();
   }
 
-  static const String VERSION = "3.8.2";
+
+
+  static const String VERSION = "3.9.1"; // Requires new key
+  // static const String VERSION = "3.8.2"; // Old private key
+  static const String APP_CHANNEL = "101_01_01_000"; 
+  static const String CORE_TOKEN_STRING_PREFIX = "com.dmzj.manhua63:60:C8:3B:75:31:3F:35:EC:41:1D:85:60:63:EB:25";
+  static const String CORE_TOKEN_STRING_SUFFIX = "+bYV5TaOBivUHM";
+
+  static String getCoreToken(String timestamp) {
+    final tokenString = '$CORE_TOKEN_STRING_PREFIX$timestamp$CORE_TOKEN_STRING_SUFFIX';
+    final digest = md5.convert(utf8.encode(tokenString)).bytes;
+    // Convert bytes to hex string, then format with colons
+    final hexString = digest.map((byte) => byte.toRadixString(16).padLeft(2, '0')).join('');
+    final newHash = hexString.toUpperCase().replaceAllMapped(RegExp(r'(.{2})(?!$)'), (match) => '${match[1]}:');
+    return '$timestamp|$newHash';
+  }
   static String get timeStamp =>
       (DateTime.now().millisecondsSinceEpoch / 1000).toStringAsFixed(0);
 
   /// 默认的参数
-  static Map<String, dynamic> getDefaultParameter({bool withUid = false}) {
+  static Map<String, dynamic> getDefaultParameter({bool withUid = false, bool useCoreToken = false}) {
+    final ts = timeStamp;
     var map = <String, dynamic>{
       "channel": "android",
-      //"version": VERSION,
-      "timestamp": timeStamp
+      "version": VERSION,
+      // "app_channel": APP_CHANNEL,
+      "_debug": "0", // Match the JS default
+      "timestamp": ts
     };
+    if (useCoreToken) {
+      map["coreToken"] = getCoreToken(ts);
+    }
     if (withUid && UserService.instance.logined.value) {
       map.addAll({"uid": UserService.instance.userId});
     }

--- a/lib/requests/common/http_client.dart
+++ b/lib/requests/common/http_client.dart
@@ -58,10 +58,11 @@ class HttpClient {
     bool needLogin = false,
     ResponseType responseType = ResponseType.json,
     bool checkCode = false,
+    Map<String, dynamic>? headers,
+    bool useCoreToken = false,
   }) async {
-    Map<String, dynamic> header = {};
     queryParameters ??= <String, dynamic>{};
-    var query = Api.getDefaultParameter(withUid: needLogin);
+    var query = Api.getDefaultParameter(withUid: needLogin, useCoreToken: useCoreToken);
     if (withDefaultParameter) {
       queryParameters.addAll(query);
     }
@@ -72,7 +73,7 @@ class HttpClient {
         queryParameters: queryParameters,
         options: Options(
           responseType: responseType,
-          headers: header,
+          headers: headers ?? {},
         ),
         cancelToken: cancel,
       );
@@ -162,19 +163,22 @@ class HttpClient {
     Map<String, dynamic>? queryParameters,
     String baseUrl = Api.BASE_URL_V4,
     CancelToken? cancel,
-    bool withDefaultParameter = true,
     bool needLogin = false,
+    bool useCoreToken = true, 
+    Map<String, dynamic>? customHeaders
   }) async {
     var result = await get(
       path,
       queryParameters: queryParameters,
       baseUrl: baseUrl,
       cancel: cancel,
-      withDefaultParameter: withDefaultParameter,
+      withDefaultParameter: true,
       needLogin: needLogin,
       responseType: ResponseType.plain,
+      useCoreToken: useCoreToken,
+      headers: customHeaders
     );
-    var resultBytes = Api.decryptV4(result);
+    var resultBytes = Api.decryptV4New(result);
     return resultBytes;
   }
 


### PR DESCRIPTION
#260 #250 #259 
更新了v4接口的解密，加入了coreToken的生成，更新了漫画接口。现在应该和官方3.9.1的apk的实现一致了。
这个接口会强制校验coreToken，并通过uid鉴权判断是否下发chapter。使用了以前一直用的uid，看起来是还能阅读神隐漫画的。